### PR TITLE
Fix clobbering of repeated scalar values

### DIFF
--- a/lib/betterlog/log/event.rb
+++ b/lib/betterlog/log/event.rb
@@ -80,6 +80,8 @@ module Betterlog
         ]
 
         def perform(object)
+          return object if IN_JSON === object
+
           if @seen.key?(object.__id__)
             :circular
           else
@@ -89,8 +91,6 @@ module Betterlog
               h.each_with_object({}) { |(k, v), h| h[k.to_s.to_sym] = perform(v) }
             when a = object.ask_and_send(:to_ary)
               a.map { |o| perform(o) }
-            when IN_JSON === object
-              object
             else
               object.to_s
             end

--- a/spec/betterlog/log/event_spec.rb
+++ b/spec/betterlog/log/event_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Betterlog::Log::Event do
+  describe '#to_json' do
+    it 'can deal with circular arrays' do
+      circular_array = [].tap { |arr| arr << arr }
+      event = Betterlog::Log::Event.new(array: circular_array)
+      expect(event.to_json).to include('"array":[["circular"]]')
+    end
+
+    # TODO: this currently crashes in tins' #symbolize_keys_recursive
+    xit 'can deal with circular hashes' do
+      circular_hash = {}.tap { |hash| hash['foo'] = hash }
+      event = Betterlog::Log::Event.new(hash: circular_hash)
+      expect(event.to_json).to include('"hash":{"foo":"circular"}')
+    end
+
+    # regression test
+    it 'does not replace repeated scalar objects with "circular"' do
+      event = Betterlog::Log::Event.new(array: [true, true])
+      expect(event.to_json).to include('"array":[true,true],')
+    end
+  end
+end


### PR DESCRIPTION
before:

`Log.info(meta: [true, nil, true, nil]) => {"meta": [true, null, "circular", "circular"]}`

after:

`Log.info(meta: [true, nil, true, nil]) => {"meta": [true, null, true, null]}`